### PR TITLE
Problem with unicode titles

### DIFF
--- a/disqus/api.py
+++ b/disqus/api.py
@@ -64,7 +64,7 @@ class DisqusClient(object):
                 request_url += '&%s' % urlencode(params)
             request = urllib2.Request(request_url)
         elif request_method == 'POST':
-            request = urllib2.Request(request_url, urlencode(params))
+            request = urllib2.Request(request_url, urlencode(params,doseq=1))
         return request
 
     def call(self, method, **params):


### PR DESCRIPTION
Hi!

   Thanks for the projects, but I had some posts that the **unicode** for it included the title.

```
urlencode has two behaviors one that is governed by the doseq param. if it is zero it does a very stupid quote_plus(str(k)) ignoring any unicode and crashing.

Cheers!
   Adriano
```
