### PR TITLE
HTML Validation error while using disqus_show_comments tag

### DIFF
--- a/disqus/templates/disqus/show_comments.html
+++ b/disqus/templates/disqus/show_comments.html
@@ -11,6 +11,7 @@
 		dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
 		(document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
 	})();
+/* ]]> */
 </script>
 <noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
 <a href="http://disqus.com" class="dsq-brlink">blog comments powered by <span class="logo-disqus">Disqus</span></a>


### PR DESCRIPTION
In pull request closed CDATA section in show_comments.html template.

If approve please update PyPI djando-disqus package.
