### PR TITLE
Use stdlib JSON when available

### DIFF
--- a/disqus/api.py
+++ b/disqus/api.py
@@ -1,7 +1,10 @@
 from urllib import urlencode
 import urllib2
 
-from django.utils import simplejson as json
+try:
+    import json
+except ImportError:
+    from django.utils import simplejson as json
 
 # A custom ProxyHandler for the urllib2 module that will not
 # auto-detect proxy settings


### PR DESCRIPTION
Fall back to deprecated Django utils copy of simplejson otherwise.
