### PR TITLE
set_disqus_identifier tag can get non-string args

### DIFF
--- a/disqus/templatetags/disqus_tags.py
+++ b/disqus/templatetags/disqus_tags.py
@@ -21,7 +21,7 @@ def set_disqus_developer(context, disqus_developer):
 # Set the disqus_identifier variable to some unique value. Defaults to page's URL
 @register.simple_tag(takes_context=True)
 def set_disqus_identifier(context, *args):
-    context['disqus_identifier'] = "".join(args)
+    context['disqus_identifier'] = ''.join(map(str, args))
     return ""
 
 # Set the disqus_url variable to some value. Defaults to page's location


### PR DESCRIPTION
In other case example from docs doesn't work http://django-disqus.readthedocs.org/en/latest/templatetags.html#set-disqus-identifier
