### PR TITLE
json imported for newer python versions, simplejson if exception

### DIFF
--- a/disqus/__init__.py
+++ b/disqus/__init__.py
@@ -2,7 +2,10 @@ import urllib
 import urllib2
 
 from django.core.management.base import CommandError
-from django.utils import simplejson as json
+try:
+    import json
+except ImportError:
+    from django.utils import simplejson as json
 from django.conf import settings
 
 def call(method, data, post=False):

--- a/disqus/management/commands/disqus_dumpdata.py
+++ b/disqus/management/commands/disqus_dumpdata.py
@@ -1,7 +1,10 @@
 from optparse import make_option
 
 from django.core.management.base import NoArgsCommand, CommandError
-from django.utils import simplejson as json
+try:
+    import json
+except ImportError:
+    from django.utils import simplejson as json
 
 from disqus.api import DisqusClient
 

--- a/disqus/management/commands/disqus_export.py
+++ b/disqus/management/commands/disqus_export.py
@@ -5,7 +5,6 @@ from django.conf import settings
 from django.contrib import comments
 from django.contrib.sites.models import Site
 from django.core.management.base import NoArgsCommand
-from django.utils import simplejson as json
 
 from disqus.api import DisqusClient
 

--- a/disqus/templatetags/disqus_tags.py
+++ b/disqus/templatetags/disqus_tags.py
@@ -1,16 +1,18 @@
 import base64
 import hashlib
 import hmac
-import simplejson
+try:
+    import json
+except ImportError:
+    from django.utils import simplejson as json
 import time
 
 from django import template
 from django.conf import settings
 from django.contrib.sites.models import Site
-from django.utils.functional import curry
-from django.utils.encoding import force_unicode
 
 register = template.Library()
+
 
 # Set the disqus_developer variable to 0/1. Default is 0
 @register.simple_tag(takes_context=True)
@@ -18,11 +20,13 @@ def set_disqus_developer(context, disqus_developer):
     context['disqus_developer'] = disqus_developer
     return ""
 
+
 # Set the disqus_identifier variable to some unique value. Defaults to page's URL
 @register.simple_tag(takes_context=True)
 def set_disqus_identifier(context, *args):
     context['disqus_identifier'] = "".join(args)
     return ""
+
 
 # Set the disqus_url variable to some value. Defaults to page's location
 @register.simple_tag(takes_context=True)
@@ -30,11 +34,13 @@ def set_disqus_url(context, *args):
     context['disqus_url'] = "".join(args)
     return ""
 
+
 # Set the disqus_title variable to some value. Defaults to page's title or URL
 @register.simple_tag(takes_context=True)
 def set_disqus_title(context, disqus_title):
     context['disqus_title'] = disqus_title
     return ""
+
 
 # Set the disqus_category_id variable to some value. No default. See
 # http://help.disqus.com/customer/portal/articles/472098-javascript-configuration-variables#disqus_category_id
@@ -43,18 +49,20 @@ def set_disqus_category_id(context, disqus_category_id):
     context['disqus_category_id'] = disqus_category_id
     return ""
 
+
 def get_config(context):
     """
     return the formatted javascript for any disqus config variables
     """
     conf_vars = ['disqus_developer', 'disqus_identifier', 'disqus_url',
-        'disqus_title', 'disqus_category_id']
-    
+                 'disqus_title', 'disqus_category_id']
+
     output = []
     for item in conf_vars:
         if item in context:
             output.append('\tvar %s = "%s";' % (item, context[item]))
     return '\n'.join(output)
+
 
 @register.simple_tag(takes_context=True)
 def disqus_dev(context):
@@ -68,6 +76,7 @@ def disqus_dev(context):
     var disqus_url = '//%s%s';
 </script>""" % (Site.objects.get_current().domain, context['request'].path)
     return ""
+
 
 @register.simple_tag(takes_context=True)
 def disqus_sso(context):
@@ -86,7 +95,7 @@ def disqus_sso(context):
     if user.is_anonymous():
         return ""
     # create a JSON packet of our data attributes
-    data = simplejson.dumps({
+    data = json.dumps({
         'id': user.id,
         'username': user.username,
         'email': user.email,
@@ -97,7 +106,7 @@ def disqus_sso(context):
     timestamp = int(time.time())
     # generate our hmac signature
     sig = hmac.HMAC(DISQUS_SECRET_KEY, '%s %s' % (message, timestamp), hashlib.sha1).hexdigest()
- 
+
     # return a script tag to insert the sso message
     return """<script type="text/javascript">
 var disqus_config = function() {
@@ -111,6 +120,7 @@ this.page.api_key = "%(pub_key)s";
         pub_key=DISQUS_PUBLIC_KEY,
     )
 
+
 @register.inclusion_tag('disqus/num_replies.html', takes_context=True)
 def disqus_num_replies(context, shortname=''):
     """
@@ -118,20 +128,22 @@ def disqus_num_replies(context, shortname=''):
     #disqus_thread anchor into the threads comment count.
     """
     shortname = getattr(settings, 'DISQUS_WEBSITE_SHORTNAME', shortname)
-    
+
     return {
         'shortname': shortname,
         'config': get_config(context),
     }
 
+
 @register.inclusion_tag('disqus/recent_comments.html', takes_context=True)
-def disqus_recent_comments(context, shortname='', num_items=5, excerpt_length=200, hide_avatars=0, avatar_size=32):
+def disqus_recent_comments(context, shortname='', num_items=5,
+                           excerpt_length=200, hide_avatars=0, avatar_size=32):
     """
     Return the HTML/js code which shows recent comments.
 
     """
     shortname = getattr(settings, 'DISQUS_WEBSITE_SHORTNAME', shortname)
-    
+
     return {
         'shortname': shortname,
         'num_items': num_items,
@@ -140,6 +152,7 @@ def disqus_recent_comments(context, shortname='', num_items=5, excerpt_length=20
         'excerpt_length': excerpt_length,
         'config': get_config(context),
     }
+
 
 @register.inclusion_tag('disqus/show_comments.html', takes_context=True)
 def disqus_show_comments(context, shortname=''):


### PR DESCRIPTION
simple json is depreciated in newer version of python beyond 2.5 and uses json instead. Code is modified to import json for newer version of python while simplejson is used for older verisions