### PR TITLE
__init__.py should use json instead of simplejson

### DIFF
--- a/disqus/__init__.py
+++ b/disqus/__init__.py
@@ -2,7 +2,10 @@ import urllib
 import urllib2
 
 from django.core.management.base import CommandError
-from django.utils import simplejson as json
+try:
+    import json
+except ImportError:
+    from django.utils import simplejson as json
 from django.conf import settings
 
 def call(method, data, post=False):


### PR DESCRIPTION
This has been fixed in api.py, a while ago.
I have just upgraded to 1.7 and simplejson is completely removed now, not just depreciated.