### PR TITLE
adding support for Django >= 1.7

### DIFF
--- a/disqus/__init__.py
+++ b/disqus/__init__.py
@@ -2,8 +2,12 @@ import urllib
 import urllib2
 
 from django.core.management.base import CommandError
-from django.utils import simplejson as json
 from django.conf import settings
+
+try:
+    from django.utils import simplejson as json
+except:
+    pass
 
 def call(method, data, post=False):
     """


### PR DESCRIPTION
django.utils.simplejson was deprecated in Django 1.5, and removed entirely in Django 1.7.