### PR TITLE
fix for disqus_sso tag

### DIFF
--- a/disqus/templates/disqus/disqus_sso.html
+++ b/disqus/templates/disqus/disqus_sso.html
@@ -2,5 +2,16 @@
     var disqus_config = function() {
         this.page.remote_auth_s3 = "{{ message }} {{ sig }} {{ timestamp }}";
         this.page.api_key = "{{ pub_key }}";
+
+        // This adds the custom login/logout functionality
+        this.sso = {
+              {% if SSO_NAME %}name:   "{{ SSO_NAME }}",{% endif %}
+              {% if SSO_BUTTON %}button: "{{ SSO_BUTTON }}",{% endif %}
+              {% if SSO_ICON %}icon:   "{{ SSO_ICON }}",{% endif %}
+              {% if SSO_URL %}url:    "{{ SSO_URL }}",{% endif %}
+              {% if SSO_LOGOUT %}logout: "{{ SSO_LOGOUT }}",{% endif %}
+              {% if SSO_WIDTH %}width:  "{{ SSO_WIDTH }}",{% endif %}
+              {% if SSO_HEIGHT %}height: "{{ SSO_HEIGHT }}",{% endif %}
+        };
     }
 </script>

--- a/disqus/templatetags/disqus_tags.py
+++ b/disqus/templatetags/disqus_tags.py
@@ -93,20 +93,30 @@ def disqus_sso(context):
     if DISQUS_PUBLIC_KEY is None:
         return "<p>You need to set DISQUS_PUBLIC_KEY before you can use SSO</p>"
 
+    SSO_AVATAR = getattr(settings, 'SSO_AVATAR', None)
+    SSO_NAME = getattr(settings, 'SSO_NAME', None)
+    SSO_BUTTON = getattr(settings, 'SSO_BUTTON', None)
+    SSO_ICON = getattr(settings, 'SSO_ICON', None)
+    SSO_URL = getattr(settings, 'SSO_URL', None)
+    SSO_LOGOUT = getattr(settings, 'SSO_LOGOUT', None)
+    SSO_WIDTH = getattr(settings, 'SSO_WIDTH', None)
+    SSO_HEIGHT = getattr(settings, 'SSO_HEIGHT', None)
+
     user = context['user']
 
-    if user.is_anonymous():
-        return ""
+    if user.is_authenticated():
+        # create a JSON packet of our data attributes
+        data = json.dumps({
+            'id': user.id,
+            'username': user.username,
+            'email': user.email,
+            'avatar': eval(SSO_AVATAR),
+        })
 
-    # create a JSON packet of our data attributes
-    data = json.dumps({
-        'id': user.id,
-        'username': user.username,
-        'email': user.email,
-    })
-
-    # encode the data to base64
-    message = base64.b64encode(data.encode('utf-8'))
+        # encode the data to base64
+        message = base64.b64encode(data.encode('utf-8')).decode()
+    else:
+        message = None
 
     # generate a timestamp for signing the message
     timestamp = int(time.time())
@@ -119,10 +129,17 @@ def disqus_sso(context):
     sig = hmac.HMAC(key, msg, digestmod).hexdigest()
 
     return  dict(
-        message=message,
-        timestamp=timestamp,
-        sig=sig,
-        pub_key=DISQUS_PUBLIC_KEY,
+        message = message,
+        timestamp = timestamp,
+        sig = sig,
+        pub_key = DISQUS_PUBLIC_KEY,
+        SSO_NAME = SSO_NAME,
+        SSO_BUTTON = SSO_BUTTON,
+        SSO_ICON = SSO_ICON,
+        SSO_URL = SSO_URL,
+        SSO_LOGOUT = SSO_LOGOUT,
+        SSO_WIDTH = SSO_WIDTH,
+        SSO_HEIGHT = SSO_HEIGHT,
     )
 
 @register.inclusion_tag('disqus/num_replies.html', takes_context=True)


### PR DESCRIPTION
**This script works in python2 and python3**



This are the settings that need configure:

###### Necessary
- DISQUS_SECRET_KEY: Secret Key Disqus APP
- DISQUS_PUBLIC_KEY: Public Key Disqus APP


###### Optional
- SSO_AVATAR: this value is a object. example with allauth: `SSO_AVATAR = 'user.socialaccount_set.all()[0].get_avatar_url()'`


- SSO_NAME
- SSO_BUTTON
- SSO_ICON
- SSO_URL
- SSO_LOGOUT
- SSO_WIDTH
- SSO_HEIGHT


For configure the variables use this help article from disqus:
* https://help.disqus.com/customer/portal/articles/236206#user-data
* https://help.disqus.com/customer/portal/articles/236206#sso-login