### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -9,4 +9,4 @@ Features:
 - Templatetags
 - Exporting Comments as WXR
 
-The documentation is available at [http://django-disqus.readthedocs.org/](http://django-disqus.readthedocs.org/).
+The documentation is available at [https://django-disqus.readthedocs.io/](https://django-disqus.readthedocs.io/).

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     description='Export comments and integrate DISQUS into your Django website',
     author='Arthur Koziel',
     author_email='arthur@arthurkoziel.com',
-    url='http://django-disqus.readthedocs.org',
+    url='https://django-disqus.readthedocs.io',
     license='New BSD License',
     classifiers=[
       'Framework :: Django',


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.