### PR TITLE
Updated tags to use new Disqus format. Refs #75

### DIFF
--- a/disqus/__init__.py
+++ b/disqus/__init__.py
@@ -1,7 +1,7 @@
 import json
+from urllib.request import urlopen
+from urllib.parse import urlencode
 
-from django.utils.six.moves.urllib.parse import urlencode
-from django.utils.six.moves.urllib.request import urlopen
 from django.core.management.base import CommandError
 
 

--- a/disqus/templates/disqus/disqus_dev.html
+++ b/disqus/templates/disqus/disqus_dev.html
@@ -1,6 +1,0 @@
-{% if disqus_url %}
-    <script type="text/javascript">
-        var disqus_developer = 1;
-        var disqus_url = '{{ disqus_url }}';
-    </script>
-{% endif %}

--- a/disqus/templates/disqus/num_replies.html
+++ b/disqus/templates/disqus/num_replies.html
@@ -1,13 +1,1 @@
-<script type="text/javascript">
-{% block config_variables %}
-	var disqus_shortname = '{{ shortname }}';
-{{ config|safe }}
-{% endblock %}
-	/* * * DON'T EDIT BELOW THIS LINE * * */
-	(function () {
-		var s = document.createElement('script'); s.async = true;
-		s.type = 'text/javascript';
-		s.src = '//' + disqus_shortname + '.disqus.com/count.js';
-		(document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
-	}());
-</script>
+<script id="dsq-count-scr" src="//{{ shortname }}.disqus.com/count.js" async></script>

--- a/disqus/templates/disqus/recent_comments.html
+++ b/disqus/templates/disqus/recent_comments.html
@@ -1,10 +1,3 @@
 <div id="dsq-recent-comments" class="dsq-widget">
-<script type="text/javascript">
-{% block config_variables %}
-	var disqus_shortname = '{{ shortname }}';
-{{ config|safe }}
-{% endblock %}
-</script>
-<script src='//{{ shortname }}.disqus.com/recent_comments_widget.js?num_items={{ num_items }}&hide_avatars={{ hide_avatars }}&avatar_size={{ avatar_size }}&excerpt_length={{ excerpt_length }}'>
-</script>
+<script src='//{{ shortname }}.disqus.com/recent_comments_widget.js?num_items={{ num_items }}&hide_avatars={{ hide_avatars }}&avatar_size={{ avatar_size }}&excerpt_length={{ excerpt_length }}'></script>
 </div>

--- a/disqus/templates/disqus/show_comments.html
+++ b/disqus/templates/disqus/show_comments.html
@@ -1,17 +1,19 @@
 <div id="disqus_thread"></div>
-<script type="text/javascript">
-/* <![CDATA[ */
-{% block config_variables %}
-	var disqus_shortname = '{{ shortname }}';
+<script>
+
+/**
+*  RECOMMENDED CONFIGURATION VARIABLES: EDIT AND UNCOMMENT THE SECTION BELOW TO INSERT DYNAMIC VALUES FROM YOUR PLATFORM OR CMS.
+*  LEARN WHY DEFINING THESE VARIABLES IS IMPORTANT: https://disqus.com/admin/universalcode/#configuration-variables*/
+
+var disqus_config = function () {
 {{ config|safe}}
-{% endblock %}
-	/* * * DON'T EDIT BELOW THIS LINE * * */
-	(function() {
-		var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-		dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
-		(document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
-	})();
-/* ]]> */
+};
+
+(function() { // DON'T EDIT BELOW THIS LINE
+var d = document, s = d.createElement('script');
+s.src = '//{{ shortname }}.disqus.com/embed.js';
+s.setAttribute('data-timestamp', +new Date());
+(d.head || d.body).appendChild(s);
+})();
 </script>
-<noscript>Please enable JavaScript to view the <a href="//disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
-<a href="//disqus.com" class="dsq-brlink">blog comments powered by <span class="logo-disqus">Disqus</span></a>
+<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>


### PR DESCRIPTION
Added variable mapping for backwards compatibility. This is to address issue #75 

In my testing it works as expected (which 0.5 was no longer working for me - in dev environments)

Mostly related to the updated tag format for counts and showing comments. SSO didn't change. Dev tags are no longer needed / supported.